### PR TITLE
Pass non-Remarkable props down to the Container.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,14 @@ import Markdown from 'remarkable';
 class Remarkable extends React.Component {
 
   render() {
-    var Container = this.props.container;
+    var {
+      container: Container,
+      children, options, source, // ⬅ remove Remarkable props
+      ...props // ⬅ only pass non-Remarkable props
+    } = this.props;
 
     return (
-      <Container>
+      <Container {...props}>
         {this.content()}
       </Container>
     );


### PR DESCRIPTION
Inspired by: https://github.com/acdlite/react-remarkable/pull/30